### PR TITLE
Consider seismic zone

### DIFF
--- a/createSAM/MDOF-LU/Building.cpp
+++ b/createSAM/MDOF-LU/Building.cpp
@@ -72,6 +72,26 @@ Building::BldgOccupancy Building::s2BldgOccupancy(string s)
     return unknown;
 }
 
+Building::SeismicZone Building::s2SeismicZone(string s)
+{
+	transform(s.begin(), s.end(), s.begin(), ::toupper);
+
+	if (s == "Z0")
+		return Z0;
+	if (s == "Z1")
+		return Z1;
+	if (s == "Z2A")
+		return Z2A;
+	if (s == "Z2B")
+		return Z2B;
+	if (s == "Z3")
+		return Z3;
+	if (s == "Z4")
+		return Z4;
+
+	return UNKNOWNZONE;
+}
+
 void
 Building::readBIM(const char *event, const char *bim)
 {
@@ -122,11 +142,16 @@ Building::readBIM(const char *event, const char *bim, const char *sam)
   json_t *nType = json_object_get(GI,"numStory");
   json_t *hType = json_object_get(GI,"height");
   json_t *yType = json_object_get(GI,"yearBuilt");
+  json_t *zType = json_object_get(GI, "seismicZone");
 
   const char *type = json_string_value(sType);
   string s(type);
 
   strutype=s2StruType(s);
+
+  const char *type1 = json_string_value(zType);
+  string s1(type1);
+  zone = s2SeismicZone(s1);
 
   year=json_integer_value(yType);
   nStory=json_integer_value(nType);

--- a/createSAM/MDOF-LU/Building.h
+++ b/createSAM/MDOF-LU/Building.h
@@ -14,6 +14,7 @@ class Building
 public:
     enum StruType{RM1, RM2, URM, C1, C2, C3, W1, W2, S1, S2, S3, S4, S5, PC1, PC2, MH, UNKNOWN}; //Hazus structural type
     enum BldgOccupancy{office, education, healthcare, hospitality, residence, retail, warehouse, research, unknown};
+	enum SeismicZone{Z0, Z1, Z2A, Z2B, Z3, Z4, UNKNOWNZONE};	//UBC seismic zone, to determine codelevel
 
     struct EDP{     //engineering demand parameters
       vector<double> IDR; // Inter-story drift ratio. size = nStory
@@ -49,6 +50,9 @@ public:
     double clpsMedian;	    //collapse median. unit: m/s^2
     double clpsDispersion;  //collapse dispersion
     
+	SeismicZone zone;
+	SeismicZone s2SeismicZone(string s);
+
     //building structural info
     vector <InterstoryParam> interstoryParams;
     vector <FloorParam> floorParams;
@@ -64,6 +68,7 @@ public:
     double lambda(int n) {
       return 0.4053*(double)(n*n)+0.405*(double)(n)+0.1869;
     }
+
 };
 
 #endif // BUILDING_H

--- a/createSAM/MDOF-LU/HazusSAM_Generator.cpp
+++ b/createSAM/MDOF-LU/HazusSAM_Generator.cpp
@@ -85,14 +85,55 @@ void HazusSAM_Generator::CalcBldgPara(Building *bldg)
     bldg->floorParams.resize(bldg->nStory);
 
     //Determine seismic design level
-    // (Need further improvement: does not include low-code, does not consider seismic zone)
     int codelevel=0;
-    if(1973<bldg->year)
-        codelevel=0;    //high-code
-    else if (1941<=bldg->year && bldg->year<=1973)
-        codelevel=1;    //moderate-code
-    else
-        codelevel=3;    //pre-code
+	switch (bldg->zone)
+	{
+	case 0:
+		codelevel = 3;	//pre-code
+		break;
+	case 1:
+		if (1975 < bldg->year)
+			codelevel = 2;	//low-code
+		else
+			codelevel = 3;	//pre-code
+		break;
+	case 2:
+		if (1941 <= bldg->year)
+			codelevel = 2;	//low-code
+		else
+			codelevel = 3;	//pre-code
+		break;
+	case 3:
+		if (1975 < bldg->year)
+			codelevel = 1;	//moderate-code
+		else if (1941 <= bldg->year && bldg->year <= 1975)
+			codelevel = 2;	//low-code
+		else
+			codelevel = 3;	//pre-code
+		break;
+	case 4:
+		if (1941 <= bldg->year)
+			codelevel = 1;	//moderate-code
+		else
+			codelevel = 3;	//pre-code
+		break;
+	case 5:
+		if (1975 < bldg->year)
+			codelevel = 0;	//high-code
+		else if (1941 <= bldg->year && bldg->year <= 1975)
+			codelevel = 1;	//moderate-code
+		else
+			codelevel = 3;	//pre-code
+		break;
+	default:
+		if (1975 < bldg->year)
+			codelevel = 0;	//high-code
+		else if (1941 <= bldg->year && bldg->year <= 1975)
+			codelevel = 1;	//moderate-code
+		else
+			codelevel = 3;	//pre-code
+		break;
+	}
 
     bldg->dampingRatio=hazus[codelevel][strucType].damp;
 


### PR DESCRIPTION
The MDOF code is modified to consider seismic zone (based on HAZUS). 

NOTE: This function requires a new key "seismicZone" in BIM json file.

Chujin Sun
PhD student of Prof. Lu